### PR TITLE
Support downloading extra files

### DIFF
--- a/binary.go
+++ b/binary.go
@@ -1,10 +1,14 @@
 package regression
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/alcortesm/tgz"
 	"gopkg.in/src-d/go-errors.v1"
@@ -17,6 +21,12 @@ var regRelease = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
 // the release tarball.
 var ErrBinaryNotFound = errors.NewKind("binary not found in release tarball")
 
+// ErrTarball is returned when there is a problem with a tarball.
+var ErrTarball = errors.NewKind("cannot unpack tarball %s")
+
+// ErrExtraFile is returned when there is a problem saving an extra file.
+var ErrExtraFile = errors.NewKind("cannot save extra file %s")
+
 // Binary struct contains information and functionality to prepare and
 // use a binary version.
 type Binary struct {
@@ -26,6 +36,7 @@ type Binary struct {
 	releases *Releases
 	config   Config
 	tool     Tool
+	cacheDir string
 }
 
 // NewBinary creates a new Binary structure.
@@ -59,12 +70,13 @@ func (b *Binary) Download() error {
 			return err
 		}
 
-		binary, err := build.Build()
+		cacheDir, binary, err := build.Build()
 		if err != nil {
 			return err
 		}
 
 		b.Path = binary
+		b.cacheDir = cacheDir
 		return nil
 
 	case b.Version == "latest":
@@ -77,6 +89,7 @@ func (b *Binary) Download() error {
 
 	case !b.IsRelease():
 		b.Path = b.Version
+		b.cacheDir = filepath.Dir(b.Version)
 		return nil
 	}
 
@@ -89,10 +102,11 @@ func (b *Binary) Download() error {
 	if exist {
 		log.Debugf("Binary for %s already downloaded", b.Version)
 		b.Path = cacheName
+		b.cacheDir = filepath.Dir(b.Version)
 		return nil
 	}
 
-	log.Debugf("Dowloading version %s", b.Version)
+	log.Debugf("Downloading version %s", b.Version)
 	err = b.downloadRelease()
 	if err != nil {
 		log.Errorf(err, "Could not download version %s", b.Version)
@@ -100,8 +114,14 @@ func (b *Binary) Download() error {
 	}
 
 	b.Path = cacheName
+	b.cacheDir = filepath.Dir(cacheName)
 
 	return nil
+}
+
+// ExtraFile returns the path from a file in the cache directory.
+func (b *Binary) ExtraFile(name string) string {
+	return filepath.Join(b.cacheDir, name)
 }
 
 func (b *Binary) downloadRelease() error {
@@ -112,7 +132,7 @@ func (b *Binary) downloadRelease() error {
 	defer os.RemoveAll(tmpDir)
 
 	download := filepath.Join(tmpDir, "download.tar.gz")
-	err = b.releases.Get(b.Version, b.tarName(), download)
+	source, err := b.releases.Get(b.Version, b.tarName(), download)
 	if err != nil {
 		return err
 	}
@@ -125,13 +145,32 @@ func (b *Binary) downloadRelease() error {
 
 	binary := filepath.Join(path, b.dirName(), b.tool.Name)
 	err = CopyFile(binary, b.cacheName(), 0755)
+	if err != nil {
+		return err
+	}
 
-	return err
+	if len(b.tool.ExtraFiles) > 0 {
+		extra := filepath.Join(tmpDir, "extra.tar.gz")
+		err := Download(source, extra)
+		if err != nil {
+			return ErrTarball.Wrap(err, extra)
+		}
+
+		// skip the first directory as files inside the source tar are inside
+		// a directory, for example:
+		//   src-d-gitbase-c533882/_testdata/regression.yml
+		cachePath := b.config.VersionPath(b.Version)
+		err = GetExtras(extra, cachePath, b.tool.ExtraFiles, 1)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (b *Binary) cacheName() string {
-	binName := fmt.Sprintf("%s.%s", b.tool.Name, b.Version)
-	return filepath.Join(b.config.BinaryCache, binName)
+	return b.config.BinaryPath(b.Version, b.tool.Name)
 }
 
 func (b *Binary) tarName() string {
@@ -156,4 +195,63 @@ func fileExist(path string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// GetExtras extracts the files from the tarball contained in the extras list
+// to the provided path. It can skip directories with the parameter depth.
+func GetExtras(tarball, path string, extras []string, depth int) error {
+	r, err := os.Open(tarball)
+	if err != nil {
+		return ErrTarball.Wrap(err, tarball)
+	}
+	defer r.Close()
+
+	gr, err := gzip.NewReader(r)
+	if err != nil {
+		return ErrTarball.Wrap(err, tarball)
+	}
+
+	t := tar.NewReader(gr)
+
+	for {
+		h, err := t.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return ErrTarball.Wrap(err, tarball)
+		}
+
+		name := skipDir(h.Name, depth)
+		if contains(extras, name) {
+			p := filepath.Join(path, filepath.Base(name))
+			err = IOToFile(t, p)
+			if err != nil {
+				return ErrExtraFile.Wrap(err, p)
+			}
+		}
+	}
+}
+
+func skipDir(name string, depth int) string {
+	if depth < 1 {
+		return name
+	}
+
+	s := strings.SplitN(name, string(os.PathSeparator), depth+1)
+	if len(s) < depth+1 {
+		return ""
+	}
+
+	return s[depth]
+}
+
+func contains(items []string, name string) bool {
+	for _, s := range items {
+		if s == name {
+			return true
+		}
+	}
+
+	return false
 }

--- a/binary_test.go
+++ b/binary_test.go
@@ -1,0 +1,99 @@
+package regression
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBinary(t *testing.T) {
+	require := require.New(t)
+
+	dir, err := CreateTempDir()
+	require.NoError(err)
+	defer os.RemoveAll(dir)
+
+	tool, releases := setupBinary(t)
+
+	config := NewConfig()
+	config.BinaryCache = dir
+
+	cases := []struct {
+		version  string
+		binSize  int64
+		yamlSize int64
+		ok       bool
+	}{
+		{
+			version:  "v0.18.0",
+			binSize:  39535564,
+			yamlSize: 3936,
+			ok:       true,
+		},
+		{
+			version:  "remote:v0.16.0",
+			binSize:  0,
+			yamlSize: 5072,
+			ok:       true,
+		},
+	}
+
+	for _, c := range cases {
+		err = os.RemoveAll(dir)
+		require.NoError(err)
+
+		binary := NewBinary(config, tool, c.version, releases)
+		err = binary.Download()
+
+		if !c.ok {
+			require.Error(err)
+			continue
+		}
+
+		require.NoError(err)
+
+		if c.binSize > 0 {
+			s, err := os.Stat(binary.Path)
+			require.NoError(err)
+
+			require.Equal(c.binSize, s.Size())
+		}
+
+		if c.yamlSize > 0 {
+			s, err := os.Stat(binary.ExtraFile("regression.yml"))
+			require.NoError(err)
+
+			require.Equal(c.yamlSize, s.Size())
+		}
+	}
+}
+
+func setupBinary(t *testing.T) (Tool, *Releases) {
+	t.Helper()
+
+	token := os.Getenv("REG_TOKEN")
+	if token == "" {
+		t.Skip("REG_TOKEN not provided")
+	}
+
+	tool := Tool{
+		Name:        "gitbase",
+		GitURL:      "https://github.com/src-d/gitbase",
+		ProjectPath: "github.com/src-d/gitbase",
+		BuildSteps: []BuildStep{
+			{
+				Dir:     "",
+				Command: "make",
+				Args:    []string{"dependencies", "packages"},
+			},
+		},
+		ExtraFiles: []string{
+			"_testdata/regression.yml",
+		},
+	}
+
+	releases := NewReleases("src-d", "gitbase", token)
+
+	return tool, releases
+}

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package regression
 
 import (
 	"fmt"
+	"path/filepath"
 	"runtime"
 )
 
@@ -31,18 +32,34 @@ type Config struct {
 	GitHubToken string `env:"REG_TOKEN" long:"token" short:"t" description:"Token used to connect to the API"`
 }
 
+// NewConfig returns an empty config with initialized OS.
 func NewConfig() Config {
 	return Config{
 		OS: runtime.GOOS,
 	}
 }
 
-type BuildStep struct {
-	Dir     string
-	Command string
-	Args    []string
+// VersionPath returns the path of the binary cache for an specific version.
+func (c *Config) VersionPath(version string) string {
+	return filepath.Join(c.BinaryCache, version)
 }
 
+// VersionPath returns the binary path an specific version.
+func (c *Config) BinaryPath(version, name string) string {
+	return filepath.Join(c.VersionPath(version), name)
+}
+
+// BuildStep describes a command used to build a tool.
+type BuildStep struct {
+	// Dir is the path where this command is executed.
+	Dir string
+	// Command is the executable to run.
+	Command string
+	// Args caintains the list of options to use with Command.
+	Args []string
+}
+
+// Tool describes a project to build and test.
 type Tool struct {
 	// Name has the tool name that is the same as the executable name.
 	Name string
@@ -53,6 +70,8 @@ type Tool struct {
 	ProjectPath string
 	// BuildSteps has the commands needed to build the tool.
 	BuildSteps []BuildStep
+	// ExtraFiles is a list of files used from the repository.
+	ExtraFiles []string
 }
 
 func (t Tool) DirName(os string) string {

--- a/releases_test.go
+++ b/releases_test.go
@@ -25,7 +25,7 @@ func TestReleases(t *testing.T) {
 	require.Nil(r.repoReleases)
 
 	path := filepath.Join(dir, "invalid_version")
-	err = r.Get("invalid_version", "invalid_asset", path)
+	_, err = r.Get("invalid_version", "invalid_asset", path)
 	require.Error(err)
 
 	if !ErrVersionNotFound.Is(err) {
@@ -38,7 +38,7 @@ func TestReleases(t *testing.T) {
 	list := r.repoReleases
 
 	path = filepath.Join(dir, "invalid_asset")
-	err = r.Get("v0.12.0", "invalid_asset", path)
+	_, err = r.Get("v0.12.0", "invalid_asset", path)
 	require.Error(err)
 	require.True(ErrAssetNotFound.Is(err))
 	require.False(fileExist(path))
@@ -46,7 +46,7 @@ func TestReleases(t *testing.T) {
 	require.Exactly(list, r.repoReleases)
 
 	path = filepath.Join(dir, "borges.v0.12.0")
-	err = r.Get("v0.12.0", "borges_v0.12.0_linux_amd64.tar.gz", path)
+	_, err = r.Get("v0.12.0", "borges_v0.12.0_linux_amd64.tar.gz", path)
 	require.NoError(err)
 	require.True(fileExist(path))
 }


### PR DESCRIPTION
Now the binary cache contains one directory per version with both the executable and extra files.

Related to src-d/regression-gitbase#4