### PR TITLE
add environment variables to build steps, run not only on linux

### DIFF
--- a/build.go
+++ b/build.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"gopkg.in/src-d/go-errors.v1"
@@ -252,14 +253,14 @@ func (b *Build) checkBinary(hash string) (bool, error) {
 func (b *Build) buildStep(step BuildStep) error {
 	cmd := exec.Command(step.Command, step.Args...)
 	cmd.Dir = filepath.Join(b.projectPath(), step.Dir)
-	cmd.Env = []string{
+	cmd.Env = append(step.Env, []string{
 		fmt.Sprintf("GO111MODULE=%s", os.Getenv("GO111MODULE")),
 		fmt.Sprintf("GOPATH=%s", b.GoPath),
 		fmt.Sprintf("PWD=%s", cmd.Dir),
 		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 		fmt.Sprintf("HOME=%s", os.Getenv("HOME")),
-		"PKG_OS=linux",
-	}
+		"PKG_OS=" + runtime.GOOS,
+	}...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/config.go
+++ b/config.go
@@ -44,7 +44,7 @@ func (c *Config) VersionPath(version string) string {
 	return filepath.Join(c.BinaryCache, version)
 }
 
-// VersionPath returns the binary path an specific version.
+// BinaryPath returns the binary path an specific version.
 func (c *Config) BinaryPath(version, name string) string {
 	return filepath.Join(c.VersionPath(version), name)
 }
@@ -55,8 +55,10 @@ type BuildStep struct {
 	Dir string
 	// Command is the executable to run.
 	Command string
-	// Args caintains the list of options to use with Command.
+	// Args contains the list of options to use with Command.
 	Args []string
+	// Env contains the list of environment variable to use with Command.
+	Env []string
 }
 
 // Tool describes a project to build and test.
@@ -76,10 +78,12 @@ type Tool struct {
 	ExtraFiles []string
 }
 
+// DirName returns the directory name for the tool in the given OS.
 func (t Tool) DirName(os string) string {
 	return fmt.Sprintf("%s_%s_amd64", t.Name, os)
 }
 
+// BinName returns the name of the binary.
 func (t Tool) BinName() string {
 	if t.BinaryName == "" {
 		return t.Name


### PR DESCRIPTION
- Adds possibility to customize environment variables on build steps.
- Makes it possible to run build steps in operating systems other than linux.
- Removed a few warnings I came across by adding docs to some methods.