### PR TITLE
fix bin size of test case

### DIFF
--- a/binary_test.go
+++ b/binary_test.go
@@ -27,7 +27,7 @@ func TestBinary(t *testing.T) {
 	}{
 		{
 			version:  "v0.23.1",
-			binSize:  42178428,
+			binSize:  42596563,
 			yamlSize: 5007,
 			ok:       true,
 		},


### PR DESCRIPTION
Fixes #13 

Master was failing because of the bin size, which I don't know why has changed.