### PR TITLE
Add environment variables support to server start

### DIFF
--- a/git_server.go
+++ b/git_server.go
@@ -23,7 +23,7 @@ func (s *GitServer) Start() error {
 	arg := []string{"daemon", basePath, port,
 		"--export-all", s.config.RepositoriesCache}
 
-	return s.Server.Start("git", arg...)
+	return s.Server.Start("git", nil, arg...)
 }
 
 func (s *GitServer) Url(name string) string {

--- a/server.go
+++ b/server.go
@@ -18,12 +18,15 @@ func NewServer() *Server {
 }
 
 // Start executes a command in background.
-func (s *Server) Start(name string, arg ...string) error {
+func (s *Server) Start(name string, envs map[string]string, arg ...string) error {
 	s.cmd = exec.Command(name, arg...)
 	s.cmd.Stdout = os.Stdout
 	s.cmd.Stderr = os.Stderr
 	s.cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: true,
+	}
+	for k, v := range envs {
+		s.cmd.Env = append(s.cmd.Env, k+"="+v)
 	}
 
 	err := s.cmd.Start()


### PR DESCRIPTION
Add map of environment variables to server start method.
This functionality is required by https://github.com/src-d/regression-gitbase/issues/18 