### PR TITLE
Parse pre-releases as a github release

### DIFF
--- a/binary.go
+++ b/binary.go
@@ -15,7 +15,7 @@ import (
 	"gopkg.in/src-d/go-log.v1"
 )
 
-var regRelease = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+var regRelease = regexp.MustCompile(`^v\d+\.\d+\.\d+`)
 
 // ErrBinaryNotFound is returned when the executable is not found in
 // the release tarball.


### PR DESCRIPTION
I was trying to use regression-gitbase with v0.24.0-rc3, but it failed because it was not detected as a release.
Another option would be to use https://github.com/blang/semver [ParseTolerant](https://godoc.org/github.com/blang/semver#ParseTolerant).